### PR TITLE
Added configuration for Katana

### DIFF
--- a/src/main/java/landmaster/plustic/config/Config.java
+++ b/src/main/java/landmaster/plustic/config/Config.java
@@ -58,6 +58,7 @@ public class Config extends Configuration {
 	public static boolean laserGun;
 	
 	public static float katana_combo_multiplier;
+	public static boolean katana_boosts_only_on_killing;
 	
 	private static final TIntArrayList botan_amount = new TIntArrayList(Botanical.MAX_LEVELS);
 	
@@ -143,6 +144,7 @@ public class Config extends Configuration {
 		// TOOLS
 		katana = getBoolean("Enable Katana", "tools", true, "Enable Katana");
 		katana_combo_multiplier = getFloat("Katana combo multiplier", "tools", 1.25f, 0, Float.MAX_VALUE, "Multiply combo value by this to calculate bonus damage");
+		katana_boosts_only_on_killing = getBoolean("Katana boosts only on killing", "tools", true, "Does Katana boost only on killing mob (true) or on any hit (false)?");
 		
 		laserGun = getBoolean("Enable Laser Gun", "tools", true, "Enable Laser Gun");
 		

--- a/src/main/java/landmaster/plustic/config/Config.java
+++ b/src/main/java/landmaster/plustic/config/Config.java
@@ -59,6 +59,7 @@ public class Config extends Configuration {
 	
 	public static float katana_combo_multiplier;
 	public static boolean katana_boosts_only_on_killing;
+	public static boolean katana_smooth_progression;
 	
 	private static final TIntArrayList botan_amount = new TIntArrayList(Botanical.MAX_LEVELS);
 	
@@ -145,6 +146,7 @@ public class Config extends Configuration {
 		katana = getBoolean("Enable Katana", "tools", true, "Enable Katana");
 		katana_combo_multiplier = getFloat("Katana combo multiplier", "tools", 1.25f, 0, Float.MAX_VALUE, "Multiply combo value by this to calculate bonus damage");
 		katana_boosts_only_on_killing = getBoolean("Katana boosts only on killing", "tools", true, "Does Katana boost only on killing mob (true) or on any hit (false)?");
+		katana_smooth_progression = getBoolean("Smooth Katana progression", "tools", false, "Should boosted damage of Katana change smoothly from material to material?");
 		
 		laserGun = getBoolean("Enable Laser Gun", "tools", true, "Enable Laser Gun");
 		

--- a/src/main/java/landmaster/plustic/tools/ToolKatana.java
+++ b/src/main/java/landmaster/plustic/tools/ToolKatana.java
@@ -143,7 +143,7 @@ public class ToolKatana extends SwordCore {
 		if (success) {
 			if (entity instanceof EntityLivingBase) {
 				EntityLivingBase targetLiving = (EntityLivingBase)entity;
-				if (targetLiving.getHealth() <= 0) counter += 1.0f;
+				if (targetLiving.getHealth() <= 0 || !Config.katana_boosts_only_on_killing) counter += 1.0f;
 				counter = MathHelper.clamp(counter, 0, counter_cap(stack));
 			}
 			tag.setFloat(COUNTER_TAG, counter);

--- a/src/main/java/landmaster/plustic/tools/ToolKatana.java
+++ b/src/main/java/landmaster/plustic/tools/ToolKatana.java
@@ -36,13 +36,7 @@ public class ToolKatana extends SwordCore {
 	}
 	
 	private static float counter_multiplier(float attack) {
-		if (attack <= 5) {
-			return 1.2f;
-		}
-		if (attack <= 11) {
-			return 1.35f;
-		}
-		return 1.5f;
+		return MathHelper.clamp(1.2f + 0.025f * attack, 1.2f, 1.8f);
 	}
 	
 	public static float counter_cap(ItemStack tool) {

--- a/src/main/java/landmaster/plustic/tools/ToolKatana.java
+++ b/src/main/java/landmaster/plustic/tools/ToolKatana.java
@@ -36,7 +36,16 @@ public class ToolKatana extends SwordCore {
 	}
 	
 	private static float counter_multiplier(float attack) {
-		return MathHelper.clamp(1.2f + 0.025f * attack, 1.2f, 1.8f);
+		if (Config.katana_smooth_progression) {
+			return MathHelper.clamp(1.2f + 0.025f * attack, 1.2f, 1.8f);
+		}
+		if (attack <= 5) {
+			return 1.2f;
+		}
+		if (attack <= 11) {
+			return 1.35f;
+		}
+		return 1.5f;
 	}
 	
 	public static float counter_cap(ItemStack tool) {


### PR DESCRIPTION
This pull request has two changes:
1) Katana added by this mod is very efficient weapon. But it effective *only* for simple mobs, which can be killed it one hit or two hits. For bosses it's very unefficient, because it boosts only on mob killing; but it costs like Cleaver, which is effective.
So I added configuration option to allow boost of Katana on each hit (and so make it useful for killing of bosses).
2) Katana's counter changes very abruptly from material to material. Material with attack of 5.01 has bigger multiplier then material with attack 5. And any material with attack bigger then 11 has the same counter multiplier.
I changed it, so counter multiplier changes smoothly. Also I changed maximum multiplier to 1.8 (to boost most powerful materials).
