### PR TITLE
Update ToolKatana.java

### DIFF
--- a/src/main/java/landmaster/plustic/tools/ToolKatana.java
+++ b/src/main/java/landmaster/plustic/tools/ToolKatana.java
@@ -73,7 +73,7 @@ public class ToolKatana extends SwordCore {
 				&& is != null && is.getItem() instanceof ToolKatana) {
 			float counter = TagUtil.getTagSafe(is).getFloat(COUNTER_TAG);
 			if (counter > 0) {
-				mc.fontRenderer.drawString(I18n.format("meter.plustic.katana", counter),
+				mc.fontRenderer.drawString(I18n.format("meter.plustic.katana", Math.round(counter * 10f) / 10f),
 						5, 5, Color.HSBtoRGB(Math.min(counter/(counter_cap(is)*3), 1.0f/3), 1, 1) & 0xFFFFFF, true);
 			}
 		}


### PR DESCRIPTION
# Cosmetic Katana Counter
Lock the counter to just show one decimal place, instead of having 7 because of javas imprecised floating point operations. 

![image](https://user-images.githubusercontent.com/20187163/60771765-9429bc80-a0ec-11e9-829c-ee23cbc7d686.png)
